### PR TITLE
Implement zellij output search

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $XONTRIB_OUTPUT_SEARCH_KEY='left'  # the text placeholder will be `left__`
 xontrib load output_search
 ```
 
-In [tmux](https://en.wikipedia.org/wiki/Tmux) or [zellij](https://zellij.dev/) there is [erminal multiplexer fallback](https://github.com/anki-code/xontrib-output-search/pull/4) in case the output of last cmd is not available.
+In [tmux](https://en.wikipedia.org/wiki/Tmux) or [zellij](https://zellij.dev/) there is [terminal multiplexer fallback](https://github.com/anki-code/xontrib-output-search/pull/4) in case the output of last cmd is not available.
 
 ## Use cases
 #### Get URL from output

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ xpip install -U xontrib-output-search
 
 ## Before usage
 
-After [xonsh release 0.10.0](https://github.com/xonsh/xonsh/releases/tag/0.10.0) ([4283](https://github.com/xonsh/xonsh/pull/4283)) you should set [`$XONSH_CAPTURE_ALWAYS=True`](https://xon.sh/envvars.html#xonsh-capture-always) in your `~/.xonshrc` to make output capturable. This approach has issues and we decided that the best solution for output search is to use the terminal window managers and we support [tmux](https://en.wikipedia.org/wiki/Tmux). In this case the output will be captured from the screen.
+After [xonsh release 0.10.0](https://github.com/xonsh/xonsh/releases/tag/0.10.0) ([4283](https://github.com/xonsh/xonsh/pull/4283)) you should set [`$XONSH_CAPTURE_ALWAYS=True`](https://xon.sh/envvars.html#xonsh-capture-always) in your `~/.xonshrc` to make output capturable. This approach has issues and we decided that the best solution for output search is to use the terminal window managers and we support [tmux](https://en.wikipedia.org/wiki/Tmux) or [zellij](https://zellij.dev/). In this case the output will be captured from the screen.
 
 So you have three ways to use output search:
-* Recommended. Use [tmux](https://en.wikipedia.org/wiki/Tmux) to run xonsh and use output search.
+* Recommended. Use [tmux](https://en.wikipedia.org/wiki/Tmux) or [zellij](https://zellij.dev/) to run xonsh and use output search.
 * Not recommended. Set [`$XONSH_CAPTURE_ALWAYS=True`](https://xon.sh/envvars.html#xonsh-capture-always) and be ready some tools will freeze because of capturing e.g. `git config --help`.
 * Alternative. You can [add support](https://github.com/anki-code/xontrib-output-search/blob/85a5eea39bb33377e236e0ba8e22b5e055f6bce5/xontrib/output_search.py#L81) any terminal emulator or terminal window manager like tmux that can capture the content of the terminal. PR is welcome!
 
@@ -81,7 +81,7 @@ $XONTRIB_OUTPUT_SEARCH_KEY='left'  # the text placeholder will be `left__`
 xontrib load output_search
 ```
 
-In [tmux](https://en.wikipedia.org/wiki/Tmux) there is [the tmux fallback](https://github.com/anki-code/xontrib-output-search/pull/4) in case the output of last cmd is not available.
+In [tmux](https://en.wikipedia.org/wiki/Tmux) or [zellij](https://zellij.dev/) there is [erminal multiplexer fallback](https://github.com/anki-code/xontrib-output-search/pull/4) in case the output of last cmd is not available.
 
 ## Use cases
 #### Get URL from output

--- a/xontrib/output_search.py
+++ b/xontrib/output_search.py
@@ -78,8 +78,16 @@ def _multiplexer_current_pane_contents():
     if "ZELLIJ" in __xonsh__.env:
         try:
             zellij_dump_path: str = __xonsh__.env.get("XONTRIB_OUTPUT_SEARCH_DUMP_LOCATION") or "/tmp/zellidump"
-            subprocess.run(["zellij", "action", "dump-screen", zellij_dump_path], timeout=1)
-            return _Path(zellij_dump_path).read_text()
+            dumpcmdlist = [
+              "sh",
+              "-c",
+              f"touch {zellij_dump_path}; "
+              f"chmod 600 {zellij_dump_path}; "
+              f"zellij action dump-screen {zellij_dump_path}; "
+              f"cat {zellij_dump_path}; "
+              f"rm {zellij_dump_path}"
+            ]
+            return subprocess.check_output(dumpcmdlist, timeout=1).decode()
         except:
             return None
     else:

--- a/xontrib/output_search.py
+++ b/xontrib/output_search.py
@@ -7,7 +7,8 @@ import re as _re
 
 if (not __xonsh__.env.get('XONSH_CAPTURE_ALWAYS', False) and
     not "TMUX" in __xonsh__.env and
-    not "ZELLIJ" in __xonsh__.env):
+    not "ZELLIJ" in __xonsh__.env and 
+    not "WEZTERM_PANE" in __xonsh__.env):
     print('xontrib-output-search: Capturing is not working. Please read https://github.com/tokenizer/xontrib-output-search#note')
 
 _key_meta = __xonsh__.env.get('XONTRIB_OUTPUT_SEARCH_KEY_META', 'escape')
@@ -92,6 +93,12 @@ def _multiplexer_current_pane_contents():
             return subprocess.check_output(dumpcmdlist, timeout=1).decode()
         except:
             return None
+    if "WEZTERM_PANE" in __xonsh__.env:
+        try:
+            output_str = subprocess.check_output(["wezterm", "cli", "get-text", "--pane-id", __xonsh__.env["WEZTERM_PANE"]], timeout=1).decode()
+        except:
+            return None
+
     if "XONTRIB_OUTPUT_SEARCH_REGEXES" in __xonsh__.env:
         for regex in __xonsh__.env.get("XONTRIB_OUTPUT_SEARCH_REGEXES"):
           if type(regex) is not _re.Pattern:


### PR DESCRIPTION
It says dump-screen, but testing shows it dumps the current pane 😄 

How to test: Launch zellij, launch xonsh, load output_search, try your binding.